### PR TITLE
Fixes issues with calling the omeroJSON_grabber.py script from dict2openBIS_converter.jy

### DIFF
--- a/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
+++ b/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
@@ -188,7 +188,7 @@ def calculate():
         # if an error occurs in omeroJSON_grabber.py return failure info to user
         if omero_call.returncode != 0:
             metadata_dict = {}
-            metadata_dict["Error"] = {"Error message": stderr}
+            metadata_dict["Error"] = {"Error message: An error occured when openBIS requested metadata from OMERO. Please contact your administrator."}
             metadata_dict = str(metadata_dict)
         # build openbis table from python dict
         new = '"'.join(metadata_dict.split("'"))


### PR DESCRIPTION
Fixes issues with calling the omeroJSON_grabber.py with the `commands.getstatusoutput`, by switching to `subprocess.Popen `and `communicate`, this allows:
- separate handling of stdout and stderr for better error reporting.
- safer omeroJSON_grabber.py subprocess creation to avoid shell injection.