### PR TITLE
Fixes issues with calling the omeroJSON_grabber.py script from dict2openBIS_converter.jy (RE)

### DIFF
--- a/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
+++ b/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
@@ -2,8 +2,8 @@ import base64
 import re
 from collections import OrderedDict
 import json
-import commands
 import sys
+import subprocess
 
 ##############################################################################
 #ADAPT TO YOUR SYSTEM:
@@ -155,12 +155,14 @@ def calculate():
         # get openBIS input values
         ids, idtype, owner, permID = openBIS_info()
         # call transition layer with arguments
-        cmd = "python3 %s" % PATH + " -f %s " % OUTPUT_FORMAT + " -o " + owner + " -n " + permID + " -d " + idtype + " -i " + str(ids)
-        status, metadata_dict = commands.getstatusoutput(cmd)
+        cmd = ["python3", PATH, "-f", "OUTPUT_FORMAT", "-o", owner, "-n", permID, "-d", idtype, "-i", str(ids)]
+        omero_call = subprocess.Popen(cmd, shell=False, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        metadata_dict, stderr = omero_call.communicate()
+        #####
         # if an error occurs in omeroJSON_grabber.py return failure info to user
-        if metadata_dict.startswith("Error"):
+        if omero_call.returncode != 0:
             metadata_dict = {}
-            metadata_dict['Error']={'Error message': 'An error occured when openBIS requested metadata from OMERO. Please contact your administrator.'}
+            metadata_dict['Error']={'Error message': + stderr}
             metadata_dict = str(metadata_dict)
         # build openbis table from python dict
         new = '"'.join(metadata_dict.split("'"))

--- a/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
+++ b/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
@@ -163,7 +163,7 @@ def calculate():
         # if an error occurs in omeroJSON_grabber.py return failure info to user
         if omero_call.returncode != 0:
             metadata_dict = {}
-            metadata_dict['Error']={'Error message': + stderr}
+            metadata_dict['Error']={'Error message': 'An error occured when openBIS requested metadata from OMERO. Please contact your administrator.'}
             metadata_dict = str(metadata_dict)
         # build openbis table from python dict
         new = '"'.join(metadata_dict.split("'"))

--- a/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
+++ b/src/omero_JSONQueryToolbox/dict2openBIS_converter.jy
@@ -132,11 +132,11 @@ def openBIS_info():
         # test whether input is url or comma separated ids
         if re.search("^https", idinput):
             idStr = ids_from_url(idinput)
-            # separate IDs with a single whitespace, remove all other whitespaces and commata
-            ids = ' '.join(idStr.split(',')).strip()
-        # input is not url: separate IDs with a single whitespace, remove all other whitespaces and commata
+            # remove all other whitespaces and commata
+            ids = ' '.join(idStr.split(',')).strip().split(' ')
+        # input is not url: remove all other whitespaces and commata
         else:
-            ids = ' '.join(idinput.split(',')).strip()
+            ids = ' '.join(idinput.split(',')).strip(' ').split(' ')
     else:
         return [], 'none', 'none'
     # get ID type which the user selected (IMAGES or DATASET) from property type OMERO_CONN_TYPE
@@ -155,8 +155,9 @@ def calculate():
         # get openBIS input values
         ids, idtype, owner, permID = openBIS_info()
         # call transition layer with arguments
-        cmd = ["python3", PATH, "-f", "OUTPUT_FORMAT", "-o", owner, "-n", permID, "-d", idtype, "-i", str(ids)]
-        omero_call = subprocess.Popen(cmd, shell=False, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = ["python3", PATH, "-f", "OUTPUT_FORMAT", "-o", owner, "-n", permID, "-d", idtype, "-i"] + ids
+        omero_call = subprocess.Popen(cmd, shell=False, universal_newlines=True,
+			stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         metadata_dict, stderr = omero_call.communicate()
         #####
         # if an error occurs in omeroJSON_grabber.py return failure info to user
@@ -166,7 +167,8 @@ def calculate():
             metadata_dict = str(metadata_dict)
         # build openbis table from python dict
         new = '"'.join(metadata_dict.split("'"))
-        sp = Spreadsheet(json.loads(new, object_pairs_hook=OrderedDict),cmd)
+        cmd_str = ' '.join(cmd)
+        sp = Spreadsheet(json.loads(new, object_pairs_hook=OrderedDict), cmd_str)
         metadata_spreads = from_dict(sp.data)
         
     return metadata_spreads


### PR DESCRIPTION
Fixes issues with calling the omeroJSON_grabber.py with the commands.getstatusoutput, by switching to subprocess.Popen and communicate, this allows:
-   separate handling of stdout and stderr, avoiding picking up stderr in metadata_dict
-   safer omeroJSON_grabber.py subprocess creation to avoid shell injection.

This is a RE-PR of #1 which keeps the original error message and formatting in: `dict2openBIS_converter.jy`
